### PR TITLE
refactor(ui): update TUI auth endpoints to match API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,12 @@ Now your MCP server is listening on `http://localhost:8080`.
 
 ---
 _Generated README by the openai-cli scaffolding agent._
+
+## Next Steps
+
+- Integrate remaining API endpoints into the UI client (per API_ENDPOINTS.md):
+  - Role management and user enable/disable endpoints under `/auth`
+  - Tenant, role, and permission management under `/user`
+  - WebSocket streaming via `/agent/ws`
+  - JSON-RPC tool proxy endpoint `/mcp`
+  - Any other endpoints outlined in API_ENDPOINTS.md not yet supported in the TUI

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -491,11 +491,10 @@ func runUI() error {
 		username := loginForm.GetFormItemByLabel("Username").(*tview.InputField).GetText()
 		password := loginForm.GetFormItemByLabel("Password").(*tview.InputField).GetText()
 		form := url.Values{}
-		form.Set("grant_type", "password")
 		form.Set("username", username)
 		form.Set("password", password)
 		form.Set("scope", "agent:chat")
-		resp, err := http.PostForm(cfg.AgentURL+"/auth/token", form)
+		resp, err := http.PostForm(cfg.AgentURL+"/auth/login", form)
 		msg := ""
 		if err != nil {
 			msg = fmt.Sprintf("Error: %v", err)
@@ -567,7 +566,7 @@ func runUI() error {
 			pages.AddPage("registerModal", modal, true, true)
 			return
 		}
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, cfg.AgentURL+"/users/register", buf)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, cfg.AgentURL+"/auth/register", buf)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		msg := ""


### PR DESCRIPTION
This PR:
- Switches the TUI login form to use /auth/login instead of /auth/token.
- Removes OAuth2 grant_type parameter from login form.
- Switches the registration form to use /auth/register instead of /users/register.
- Updates README.md with next steps for integrating remaining API endpoints from API_ENDPOINTS.md.

Once merged, the next step is to wire up the remaining endpoints (authentication role management, user management, WebSocket streaming, and JSON-RPC tool proxy) in the TUI.