### PR TITLE
docs: initial project wiki pages

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,46 @@
+# Architecture Overview
+
+This section describes the high-level architecture and code organization of the Vibes MCP CLI.
+
+```
+vibes-mcp-cli/
+├── cmd/                # Cobra-based CLI commands and TUI
+│   ├── root.go         # Entrypoint and global flags
+│   ├── completion.go   # 'completion' subcommand
+│   ├── chat.go         # 'chat' subcommand
+│   ├── embed.go        # 'embed' subcommand
+│   ├── models.go       # 'models' subcommand
+│   ├── serve.go        # 'serve' subcommand (HTTP server)
+│   └── ui.go           # 'ui' subcommand (terminal UI)
+
+├── internal/
+│   ├── config/         # Application configuration loader (dotenv, Viper)
+│   ├── client/         # Type-safe HTTP client for OpenAI API
+│   ├── providers/      # Provider factory and specific provider implementations
+│   └── service/        # Service layer wrapping APIClient interface
+
+├── dist/               # Prebuilt binaries for various platforms
+├── docs/               # Project documentation and wiki pages
+├── Makefile            # Common development commands
+├── docker-compose.yml  # Docker Compose configuration
+├── Dockerfile          # Container image for the CLI and server
+├── LICENSE
+└── README.md
+```
+
+## Key Components
+
+- **Cobra Commands (`cmd/`):** Define the CLI surface and TUI behavior.
+- **Config (`internal/config`):** Loads environment variables, `.env`, and config files; persists auth tokens.
+- **HTTP Client (`internal/client`):** Implements retries, backoff, and low-level HTTP calls to LLM endpoints.
+- **Providers (`internal/providers`):** Factory method to select provider implementations at runtime.
+- **Service Layer (`internal/service`):** Defines the `APIClient` interface and coordinates calls from commands.
+
+## Data Flow
+
+1. **CLI/TUI** parses user input and flags.
+2. **Config** provides API credentials and endpoints.
+3. **Providers** creates an `APIClient` implementation.
+4. **Service** calls the appropriate client method (`CreateCompletion`, etc.).
+5. **Client** sends HTTP requests to the provider's REST API.
+6. Results are returned to the CLI/TUI or HTTP server response.

--- a/docs/CLI-Usage.md
+++ b/docs/CLI-Usage.md
@@ -1,0 +1,31 @@
+# CLI Usage
+
+The `openai-cli` binary provides several subcommands for interacting with LLM providers and the built-in MCP server.
+
+## Available Commands
+
+- `completion`: Generate one-shot text completions.
+- `chat`: Send chat completion requests (single-shot or interactive REPL).
+- `embed`: Compute embeddings for input texts.
+- `models`: List available LLM models.
+- `serve`: Run the HTTP proxy server (MCP).
+- `ui`: Launch the interactive terminal UI.
+
+## Global Flags
+
+| Flag             | Description                                                       |
+|------------------|-------------------------------------------------------------------|
+| `--config`       | Path to config file (default `$HOME/.openai-cli.yaml`)            |
+| `--provider`     | Provider to use (overrides config/env; e.g., openai, anthropic)   |
+| `--api-key`      | API key (overrides config/env)                                    |
+| `--base-url`     | API base URL (overrides config/env)                               |
+| `--server-url`   | MCP server URL to proxy CLI calls                                 |
+| `--agent-url`    | Vibes Agent backend URL (for TUI auth and agent chat)             |
+| `--print-curl`   | Print the equivalent curl command instead of executing            |
+| `--log-level`    | Logging level (`debug`, `info`, `warn`, `error`)                  |
+
+Use `--help` after any command for detailed usage information. For example:
+
+```bash
+openai-cli chat --help
+```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,33 @@
+# Configuration
+
+The application can be configured using environment variables and a configuration file.
+
+## Environment Variables
+
+| Name                   | Description                                                   |
+|------------------------|---------------------------------------------------------------|
+| OPENAI_CLI_API_KEY     | API key for the LLM provider                                  |
+| OPENAI_CLI_BASE_URL    | Base URL for the LLM API (default: https://api.openai.com)    |
+| OPENAI_CLI_PROVIDER    | Default provider name (e.g., openai, anthropic)               |
+| OPENAI_CLI_LOG_LEVEL   | Logging level (`debug`, `info`, `warn`, `error`)              |
+| OPENAI_CLI_AGENT_URL   | URL of the Vibes Agent backend (default: http://localhost:8000) |
+| OPENAI_CLI_AUTH_TOKEN  | JWT token for Vibes Agent backend                             |
+| PROMPT_MODE_PASSWORD   | Password for interactive chat REPL mode                       |
+
+## Configuration File
+
+You can also use a config file (`.openai-cli.yaml`, JSON, or TOML) in your home directory or working directory. Example YAML:
+
+```yaml
+api_key: "your-openai-api-key"
+base_url: "https://api.openai.com"
+provider: "openai"
+log_level: "info"
+agent_url: "http://localhost:8000"
+auth_token: "your-jwt-token"
+templates:
+  - "Hello!"
+  - "What is the weather?"
+```
+
+CLI flags override config file values.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thank you for your interest in contributing to the Vibes MCP CLI!
+
+## Code Style
+
+- Follow Go formatting conventions (`go fmt`).
+- Keep line length ≤120 characters.
+- Use descriptive names and modular design.
+
+## Git Workflow
+
+1. Fork the repository.
+2. Create a feature branch with a descriptive name (`feat/...`, `fix/...`, `docs/...`).
+3. Commit changes with semantic messages:
+   - `feat(...)`: new feature
+   - `fix(...)`: bug fix
+   - `refactor(...)`: code refactoring
+   - `docs(...)`: documentation changes
+4. Ensure tests pass locally:
+   ```bash
+   make test
+   ```
+5. Push your branch and open a Pull Request.
+
+## Pull Request Guidelines
+
+- Provide a clear description of the changes and motivation.
+- Include relevant test coverage for new functionality.
+- Update or add documentation as needed.
+- Ensure continuous integration checks (lint, tests) pass.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,0 +1,52 @@
+# Getting Started
+
+This guide will help you get up and running with the Vibes MCP CLI.
+
+## Prerequisites
+
+- Go 1.20 or higher
+- Git
+- (Optional) Docker & Docker Compose for containerized server
+
+## Clone the repository
+
+```bash
+git clone https://github.com/rafaelkamimura/vibes-mcp-cli.git
+cd vibes-mcp-cli
+```
+
+## Installation
+
+### Using Go directly
+
+```bash
+go mod tidy
+go build -o openai-cli .
+```
+
+### Using Makefile
+
+```bash
+make init       # Copy .env and install dependencies
+make build      # Build the CLI binary
+```
+
+## Initial setup
+
+1. Copy the example environment file:
+   ```bash
+   cp .env_example .env
+   ```
+2. Edit `.env` to set your variables:
+   - `OPENAI_CLI_API_KEY`
+   - `OPENAI_CLI_BASE_URL` (optional)
+   - `OPENAI_CLI_PROVIDER` (optional)
+   - `PROMPT_MODE_PASSWORD` (for interactive chat)
+
+## Verify installation
+
+```bash
+./openai-cli --help
+```
+
+You should see the list of available commands and flags.

--- a/docs/HTTP-Server.md
+++ b/docs/HTTP-Server.md
@@ -1,0 +1,39 @@
+# HTTP MCP Server
+
+The built-in HTTP server proxies requests to supported LLM providers and exposes a JSON-RPC tool proxy.
+
+## Starting the Server
+
+```bash
+openai-cli serve --host 0.0.0.0 --port 8080
+```
+
+Use `--help` to see additional flags for host, port, and logging.
+
+## Available Endpoints
+
+- `POST /v1/completions`
+  - Single-shot text completions proxy
+- `POST /v1/chat/completions`
+  - Single-shot chat completions proxy
+- `POST /v1/embeddings`
+  - Embedding generation proxy
+- `POST /mcp`
+  - JSON-RPC 2.0 proxy for tool calls (method `call_tool`)
+  - Supports SSE streaming or JSON response based on `Accept` header
+
+### Common Headers
+
+- `Content-Type: application/json`
+- `Authorization: Bearer <API_KEY>` or set `X-Provider: <provider>` to select provider
+
+## Switching Providers
+
+Use the `X-Provider` header to specify which provider to use for a given request. If omitted, the default provider from configuration is used.
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "X-Provider: anthropic" \
+  -d '{"model":"claude-v1","messages":[{"role":"user","content":"Hi"}]}'
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,16 @@
+# Vibes MCP CLI Wiki
+
+Welcome to the **Vibes MCP CLI** (`openai-cli`) repository wiki! This wiki provides detailed documentation on installation, configuration, usage, architecture, and contribution guidelines.
+
+## Wiki Contents
+
+- [Getting Started](Getting-Started.md)
+- [Configuration](Configuration.md)
+- [CLI Usage](CLI-Usage.md)
+- [Terminal UI (TUI)](TUI-Usage.md)
+- [HTTP MCP Server](HTTP-Server.md)
+- [Providers](Providers.md)
+- [Architecture](Architecture.md)
+- [Testing](Testing.md)
+- [Contributing](Contributing.md)
+- [Roadmap](Roadmap.md)

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -1,0 +1,23 @@
+# Providers
+
+The CLI and HTTP server support multiple LLM providers via a pluggable architecture.
+
+## Supported Providers
+
+- **openai**: Official OpenAI API client (`internal/client`).
+- **anthropic**: Anthropic Claude API client (`internal/providers/anthropic`).
+- **test**: Testing stub; use `--provider test` and override `providers.TestClient` in code or tests.
+
+## Adding a New Provider
+
+1. Create a new package under `internal/providers/<provider-name>` implementing the `service.APIClient` interface.
+2. Implement methods:
+   - `CreateCompletion(ctx, CompletionsRequest)`
+   - `CreateChatCompletion(ctx, ChatCompletionsRequest)`
+   - `CreateEmbedding(ctx, EmbeddingRequest)`
+3. Register your provider in `internal/providers/provider.go`:
+   ```go
+   case "<provider-name>":
+       return yourpkg.NewClient(apiKey, baseURL), nil
+   ```
+4. Rebuild the binary; your provider is now available via `--provider <provider-name>`.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+Key features and improvements planned for upcoming releases:
+
+## Short-term
+- Integrate remaining API endpoints in the TUI (see [API_ENDPOINTS.md](API_ENDPOINTS.md)).
+  - Auth role management (`/auth/{username}/roles`).
+  - User enable/disable endpoints (`/auth/{username}/disable`, `/auth/{username}/enable`).
+  - Tenant, role, and permission CRUD under `/user`.
+  - WebSocket streaming via `/agent/ws`.
+  - JSON-RPC `/mcp` proxy for tools.
+- Improve error handling and user feedback in TUI.
+
+## Mid-term
+- Support additional providers (Azure OpenAI, AWS Bedrock).
+- Plugin architecture for custom tools and chains.
+- Metrics and observability integration (Prometheus, OpenTelemetry).
+
+## Long-term
+- GUI application for desktop platforms.
+- End-to-end example workflows and tutorials.
+- Automated release pipeline and Homebrew formula.

--- a/docs/TUI-Usage.md
+++ b/docs/TUI-Usage.md
@@ -1,0 +1,45 @@
+# Terminal UI (TUI)
+
+The TUI provides an interactive text-based interface for chat sessions and browsing Postman collections.
+
+## Launching the UI
+
+```bash
+openai-cli ui [--model MODEL] [--collection PATH]
+```
+
+### Flags
+
+- `--model`: Chat model to use (default: `gpt-3.5-turbo`).
+- `--collection`: Path to a Postman collection JSON file to load.
+
+## UI Modes
+
+Use the function keys or menu to switch between modes:
+
+- **Home**: Main menu for navigation.
+- **Chat**: Interactive chat view (send messages to LLM or MCP agent).
+- **Agent**: Chat view against the Vibes Agent backend (`/agent/chat`).
+- **Postman**: Browse and load a Postman collection for issuing HTTP requests.
+
+## Controls
+
+- **Enter**: Submit input in chat or Postman view.
+- **Esc**: Return focus to previous pane or cancel selection.
+- **Tab**: Cycle focus between input, templates, and model dropdown.
+- **j/k**: Scroll down/up in chat view (vim-style).
+- **F1/F2**: Toggle between Chat and Postman modes.
+
+## Templates & Models
+
+- Use the **Templates** dropdown to insert predefined prompts.
+- Use the **Models** dropdown to switch chat models on the fly.
+
+## Authentication
+
+On launch, you will be prompted to Login or Register (if not authenticated):
+
+- **Login** sends credentials to `/auth/login` and stores the JWT.
+- **Register** sends a new user request to `/auth/register`.
+
+Successful login unlocks the Chat and Agent views.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,34 @@
+# Testing
+
+This project includes both unit and integration tests.
+
+## Unit Tests
+
+- Located alongside code in `internal/client`, `internal/service`, and `cmd/` (e.g., `client_test.go`, `service_test.go`, `cli_test.go`).
+- Use Go's `testing` package and `httptest` for mocking HTTP interactions.
+
+Run unit tests:
+```bash
+go test ./internal/client ./internal/service ./cmd -v
+```
+
+## Integration Tests
+
+- Located in `tests/integration/`.
+- Exercise the full stack against a live Postgres database and the HTTP server.
+- Use `httpx.AsyncClient` in Go tests to call the server endpoints.
+
+Run integration tests:
+```bash
+docker-compose up -d   # start Postgres + server
+go test ./tests/integration -v
+docker-compose down
+```
+
+## Test Coverage
+
+Generate coverage report:
+```bash
+go test ./... -coverprofile=coverage.out
+go tool cover -html=coverage.out
+```


### PR DESCRIPTION
This PR adds a comprehensive project wiki under the  directory, including:
- Home page with navigation
- Getting Started guide
- Configuration reference
- CLI usage guide
- Terminal UI (TUI) usage guide
- HTTP MCP server documentation
- Provider extension guide
- Architecture overview
- Testing instructions
- Contributing guidelines
- Project roadmap

These pages will serve as the basis for ongoing documentation and knowledge sharing.